### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/pipelines/batch/src/main/java/org/openmrs/analytics/ReadJsonFilesFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/ReadJsonFilesFn.java
@@ -52,14 +52,13 @@ public class ReadJsonFilesFn extends FetchSearchPageFn<FileIO.ReadableFile> {
       if (!"Bundle".equals(resource.fhirType())) {
         log.error(
             String.format(
-                "The content of file %s is not a Bundle; type is %s.",
-                file.getMetadata().toString(), resource.fhirType()));
+                "The content of file %s is not a Bundle; type is %s.", file.getMetadata(), resource.fhirType()));
       }
       Bundle bundle = (Bundle) resource;
       updateResolvedRefIds(bundle);
       processBundle(bundle, resourceTypes);
     } catch (DataFormatException | ClassCastException e) {
-      log.error("Cannot parse content of file " + file.getMetadata().toString() + e);
+      log.error("Cannot parse content of file " + file.getMetadata() + e);
     }
   }
 
@@ -98,3 +97,6 @@ public class ReadJsonFilesFn extends FetchSearchPageFn<FileIO.ReadableFile> {
     }
   }
 }
+
+
+

--- a/pipelines/common/src/main/java/org/openmrs/analytics/GcpStoreUtil.java
+++ b/pipelines/common/src/main/java/org/openmrs/analytics/GcpStoreUtil.java
@@ -64,7 +64,7 @@ class GcpStoreUtil extends FhirStoreUtil {
     try {
       updateFhirResource(sinkUrl, resource);
     } catch (Exception e) {
-      log.error(String.format("Exception while sending to sink: %s", e.toString()));
+      log.error(String.format("Exception while sending to sink: %s", e));
     }
     return null;
   }
@@ -84,9 +84,9 @@ class GcpStoreUtil extends FhirStoreUtil {
           Collections.singletonList(
               new BearerTokenAuthInterceptor(credential.refreshAccessToken().getTokenValue())));
     } catch (IOException e) {
-      log.error("IOException while using Google APIs: {}", e.toString(), e);
+      log.error("IOException while using Google APIs: {}", e, e);
     } catch (URISyntaxException e) {
-      log.error("URI syntax exception while using Google APIs: {}", e.toString(), e);
+      log.error("URI syntax exception while using Google APIs: {}", e, e);
     }
     return null;
   }
@@ -105,9 +105,9 @@ class GcpStoreUtil extends FhirStoreUtil {
           Collections.<IClientInterceptor>singletonList(
               new BearerTokenAuthInterceptor(credential.refreshAccessToken().getTokenValue())));
     } catch (IOException e) {
-      log.error(String.format("IOException while using Google APIs: %s", e.toString()));
+      log.error(String.format("IOException while using Google APIs: %s", e));
     } catch (URISyntaxException e) {
-      log.error(String.format("URI syntax exception while using Google APIs: %s", e.toString()));
+      log.error(String.format("URI syntax exception while using Google APIs: %s", e));
     }
     return null;
   }
@@ -133,3 +133,53 @@ class GcpStoreUtil extends FhirStoreUtil {
         .build();
   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/pipelines/controller/src/main/java/org/openmrs/analytics/metrics/FlinkJobListener.java
+++ b/pipelines/controller/src/main/java/org/openmrs/analytics/metrics/FlinkJobListener.java
@@ -33,7 +33,7 @@ public class FlinkJobListener implements JobListener {
       return;
     }
 
-    logger.info("Submitting the job with ID toString {} ", this.toString());
+    logger.info("Submitting the job with ID toString {} ", this);
     FlinkPipelineMetrics.setJobClient(jobClient);
   }
 
@@ -53,3 +53,5 @@ public class FlinkJobListener implements JobListener {
     FlinkPipelineMetrics.clearJobClient();
   }
 }
+
+


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:110-el:0-sc:85-ec:0-co:4488-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:89-el:0-sc:71-ec:0-co:3542-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:67-el:0-sc:72-ec:0-co:2684-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:87-el:0-sc:62-ec:0-co:3419-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:134-el:0-sc:64-ec:0-co:4733-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:226-el:0-sc:33-ec:0-co:8347-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:108-el:0-sc:76-ec:0-co:4353-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:36-el:0-sc:65-ec:0-co:1327-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:56-el:0-sc:36-ec:0-co:2099-cl:8 -->
<!-- fingerprint:Qodana-fhir-data-pipes-UnnecessaryToStringCall-4b84f4d8bb4bcf9e2ca88ce3e2521d1c04a41449-sl:62-el:0-sc:70-ec:0-co:2391-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (8)
